### PR TITLE
ApiSecurityUtil -  Query Params Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,17 @@ let L2RequestParams = {
 }
 ```
 
-***Note: Set secret to null or undefined if you are using ApiSecurity L2 RSA256 Signing (L2RequestParams)***
+***Note 1: Set secret to null or undefined if you are using ApiSecurity L2 RSA256 Signing (L2RequestParams)***
+
+
+```
+  //Remove undefined or null query params from signing using Lodash
+   if(!_.isNil(reqProps.params)) {
+        reqProps.params = _.pickBy(reqProps.params, _.identity);
+   }
+```
+
+***Note 2: Request Query parameters that are set to undefined or null will be ignore during the formation of Signature's BaseString***
 
 **Invoking the function for ApiSecurityUtil**
 

--- a/lib/ApiSecurityUtil.js
+++ b/lib/ApiSecurityUtil.js
@@ -105,10 +105,15 @@ ApiSecurityUtil.generateSecurityHeader = (reqProps) => {
         "\"" + reqProps.prefix + "_version\": \"" + reqProps.version + "\"" +
         "}");
 
+    //Remove undefined or null query params from signing
+    if(!_.isNil(reqProps.params)) {
+        reqProps.params = _.pickBy(reqProps.params, _.identity);
+    }
+
     // merge default parameters with query/body params and sort alphabetically.
     let baseParams = sortJSON(_.merge(defaultParams, reqProps.params));
 
-    if (reqProps.method == "POST" || reqProps.method == "PUT") {
+    if (reqProps.method == "POST" || reqProps.method == "PUT" || reqProps.method == "PATCH") {
         baseParams = sortJSON(_.merge(baseParams, reqProps.formData));
     }
 


### PR DESCRIPTION
Remove query params that are undefined or null from being constructed as the signature base string.