### PR TITLE
Api signing util get token with cert string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@
 + Update superagent version for security patch
 ### V0.4.0
 + Minor improvements and typo fix in index.js
+### V0.4.1
++ There are now 3 variants to getToken in ApiSigningUtil.js
++ Typedefs has been added for ApiSigningUtil.js

--- a/lib/ApiSigningUtil.d.ts
+++ b/lib/ApiSigningUtil.d.ts
@@ -1,0 +1,16 @@
+export declare function setLogLevel(loglevel: string);
+export declare function getL1Signature(message: string | Buffer, secret: string | Buffer);
+export declare function verifyL1Signature(signature: string, secret: string | Buffer, message: string | Buffer);
+export declare function getL2Signature(message: string | Buffer, privateKey: string, passphrase: string);
+export declare function verifyL2Signature(signature: string, publicKey: string, message: string | Buffer);
+
+export declare function getPrivateKeyFromPem(pemFileName: string);
+export declare function getPublicKeyFromCer(cerFileName: string);
+
+export declare function getBaseString(authPrefix: string, signatureMethod: string, appId: string, urlPath: string, httpMethod: string, formData?: object, nonce: string, timestamp: number);
+
+export declare function getTokenFromSecret(realm: string, authPrefix: string, httpMethod: string, urlPath: string, appId: string, secret: string, formJson?: object, nonce?: string, timestamp?: number);
+export declare function getTokenFromCertFileName(realm: string, authPrefix: string, httpMethod: string, urlPath: string, appId: string, formJson?: string, passphrase: string, certFileName: string, nonce?: string, timestamp?: number);
+export declare function getTokenFromCertString(realm: string, authPrefix: string, httpMethod: string, urlPath: string, appId: string, formJson?: object, passphrase: string, certString: string, nonce?: string, timestamp?: number);
+
+export declare function makeHttpRequest(urlPath: string, token: string, formData?: object, httpMethod: string, port: number);

--- a/lib/ApiSigningUtil.js
+++ b/lib/ApiSigningUtil.js
@@ -143,8 +143,20 @@ ApiSigningUtil.getBaseString = (authPrefix, signatureMethod, appId, urlPath, htt
     return baseString;
 };
 
-ApiSigningUtil.getToken = (realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, passphrase, certFileName, nonce, timestamp) => {
-    winston.logEnter(realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, passphrase, certFileName, nonce, timestamp);
+ApiSigningUtil.getTokenFromSecret = (realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, nonce, timestamp) => {
+    return ApiSigningUtil.getToken(realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, null, null, nonce, timestamp, null);
+}
+
+ApiSigningUtil.getTokenFromCertFileName = (realm, authPrefix, httpMethod, urlPath, appId, formJson, passphrase, certFileName, nonce, timestamp) => {
+    return ApiSigningUtil.getToken(realm, authPrefix, httpMethod, urlPath, appId, null, formJson, passphrase, certFileName, nonce, timestamp, null);
+}
+
+ApiSigningUtil.getTokenFromCertString = (realm, authPrefix, httpMethod, urlPath, appId, formJson, passphrase, certString, nonce, timestamp) => {
+    return ApiSigningUtil.getToken(realm, authPrefix, httpMethod, urlPath, appId, null, formJson, passphrase, null, nonce, timestamp, certString);
+}
+
+ApiSigningUtil.getToken = (realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, passphrase, certFileName, nonce, timestamp, certString) => {
+    winston.logEnter(realm, authPrefix, httpMethod, urlPath, appId, secret, formJson, passphrase, certFileName, nonce, timestamp, certString);
 
     let apexPrefix = authPrefix.toLowerCase();
 
@@ -173,8 +185,7 @@ ApiSigningUtil.getToken = (realm, authPrefix, httpMethod, urlPath, appId, secret
     }
     else
     {
-        let privateKey = ApiSigningUtil.getPrivateKeyFromPem(certFileName);
-
+        let privateKey = (certFileName ? ApiSigningUtil.getPrivateKeyFromPem(certFileName) : certString);
         signature = ApiSigningUtil.getL2Signature(baseString, privateKey, passphrase);
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-apex-api-security",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "APEX API security utiity. It include helper operations to generate HMAC256 and RSA256 signature",
   "private": true,
   "main": "index.js",

--- a/spec/scripts/ApiSigningUtilSpec.js
+++ b/spec/scripts/ApiSigningUtilSpec.js
@@ -308,14 +308,21 @@ describe('ApiSigning Token Test', function () {
     let liveTestToggle = true;
 
     it('Api Signed Token - Basic L1 Test', function () {
-        let token = ApiSigningUtil.getToken(realm, authPrefixL1, httpMethod,
-            url, appId, secret, null, null, null, nonce, timestamp);
+        let token = ApiSigningUtil.getTokenFromSecret(realm, authPrefixL1, httpMethod,
+            url, appId, secret, null, nonce, timestamp);
         expect(token).to.equal(expectedTokenL1);
     });
 
-    it('Api Signed Token - Basic L2 Test', function () {
-        let token = ApiSigningUtil.getToken(realm, authPrefixL2, httpMethod,
-            url, appId, null, null, passphrase, certFileName, nonce, timestamp);
+    it('Api Signed Token - Basic L2 Test with cert file', function () {
+        let token = ApiSigningUtil.getTokenFromCertFileName(realm, authPrefixL2, httpMethod,
+            url, appId, null, passphrase, certFileName, nonce, timestamp);
+        expect(token).to.equal(expectedTokenL2);
+    });
+
+    it('Api Signed Token - Basic L2 Test with cert string', function () {
+        const certString = ApiSigningUtil.getPrivateKeyFromPem(certFileName);
+        let token = ApiSigningUtil.getTokenFromCertString(realm, authPrefixL2, httpMethod,
+            url, appId, null, passphrase, certString, nonce, timestamp);
         expect(token).to.equal(expectedTokenL2);
     });
 


### PR DESCRIPTION
- Broke getToken function into 3 functions that takes in different arguments sets (secret, cert file path, cert string)
- Added type definition to ApiSigningUtil