### PR TITLE
Fix bug related to standard port (80 and 443) removal from signature url

### DIFF
--- a/lib/ApiSigningUtil.js
+++ b/lib/ApiSigningUtil.js
@@ -319,8 +319,14 @@ ApiSigningUtil.getSignatureBaseString = (baseProps) => {
         throw new Error(errorMessage);
     }
 
-    // Remove port from url
-    const signatureUrl = siteUrl.protocol + '//' + siteUrl.hostname + siteUrl.pathname;
+    // Remove port from url for 80 and 443 only
+    //const signatureUrl = siteUrl.protocol + '//' + siteUrl.hostname + siteUrl.pathname;
+    var signatureUrl = "";
+    if (siteUrl.port == "80" || siteUrl.port == "443" || siteUrl.port == "") {
+        signatureUrl = siteUrl.protocol + '//' + siteUrl.hostname + siteUrl.pathname;
+    } else {
+        signatureUrl = siteUrl.protocol + '//' + siteUrl.hostname + ":" + siteUrl.port + siteUrl.pathname;
+    }
 
     let defaultParams = ApiSigningUtil.getDefaultParam(baseProps);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,7 +1335,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
@@ -3095,7 +3095,7 @@
       }
     },
     "test-suites-apex-api-security": {
-      "version": "git+https://github.com/GovTechSG/test-suites-apex-api-security.git#04b1340c7ed62631cc8c0a49fcdb539c97ee10ad",
+      "version": "git+https://github.com/GovTechSG/test-suites-apex-api-security.git#58826d227fec55c1aa6324a9b7a21c7775fd6a2e",
       "from": "git+https://github.com/GovTechSG/test-suites-apex-api-security.git"
     },
     "text-table": {


### PR DESCRIPTION
# Description

BaseString should include http port in signing url if the port no is other than 80 and 443.

## Type of change

Please check on options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

Tested in AWS which hosted the service on port 9991. 

